### PR TITLE
Add 'SocialUserParser' for Twitter

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,9 +12,27 @@ The service as well will omit metainformation extracted that consider not releva
 
 + Request body
 ```
-  [
-    {"url": "<physical url>"},...
-  ]
+  {
+    "objects": [
+      {"url": "<physical url>"},...
+    ]
+  }
+```
+
+### Twitter Metadata
+
+If the URL requested is a Twitter user page, the response will contain a
+'twitter' key containing the following data:
+
++ Twitter User Metadata
+```
+"twitter": {
+  "user_id": "twitter_handle",
+  "bio": "twitter bio for user",
+  "android_uri": "android-app://url-to-user-in-app",
+  "avatar" { "src": "url", "alt": "alt text" },
+  "avatar_small": { "src": "url", "alt": "alt text" }
+}
 ```
 
 ## POST /api/v1/metadata/raw

--- a/metadata/parser.js
+++ b/metadata/parser.js
@@ -1,3 +1,6 @@
+'use strict';
+const URL = require('url');
+
 var SimpleParser = {
   execute: function(url, doc, metadata) {
     return new Promise((resolve, reject) => {
@@ -35,17 +38,81 @@ var SimpleParser = {
   }
 };
 
+// Given a URL to a Social Media website, determine information about the User
+// the URL relates to if any
+var SocialUserParser = {
+  parsers: {
+    "twitter.com": function(url, doc, metadata) {
+      const twitter = {};
+      const parsedUrl = URL.parse(url);
+      const dirs = parsedUrl.pathname.split("/").filter(dirComponent => dirComponent.length);
+
+      if (dirs.length === 1) {
+        twitter.user_id = dirs[0]
+      }
+
+      try {
+        const links = doc.querySelectorAll('link[rel="alternate"]');
+        if (links) {
+          for (let linkId = 0; linkId < links.length; linkId++) {
+            const link = links[linkId];
+            if (link.href.startsWith("android-app")) {
+              twitter.android_uri = link.href;
+              break;
+            }
+          }
+        }
+
+        const miniImage = doc.querySelector('.ProfileCardMini-avatarImage');
+        if (miniImage) {
+          twitter.avatar_small = {
+            src: miniImage.src,
+            alt: miniImage.alt
+          };
+        }
+
+        const normalImage = doc.querySelector('.ProfileAvatar-image');
+        if (normalImage) {
+          twitter.avatar = {
+            src: normalImage.src,
+            alt: normalImage.alt
+          };
+        }
+
+        const userData = doc.querySelector('.ProfileHeaderCard-bio');
+
+        if (userData) {
+          twitter.bio = userData.textContent;
+        }
+
+      } catch(e) {
+      }
+
+      metadata.twitter = twitter;
+      return Promise.resolve(metadata);
+    }
+  },
+  execute: function(url, doc, metadata) {
+    const parsedUrl = URL.parse(url);
+    if (parsedUrl.hostname in this.parsers) {
+      return Promise.resolve(this.parsers[parsedUrl.hostname].apply(this, arguments));
+    } else {
+      return Promise.resolve(metadata);
+    }
+  }
+};
+
 
 module.exports = {
   parse: function parse(url, doc) {
-    var parsers = [SimpleParser];
+    var parsers = [SimpleParser, SocialUserParser];
 
     // Add other parsers on demand, they will execute in waterfall mode
     // if (url.contains('youtube')) {
-    //   parsers.push(YouTubeParser) 
+    //   parsers.push(YouTubeParser)
     // }
     // Below you have a simple example:
-    
+
     parsers.push({
       execute: function(url, doc, metadata) {
         metadata.watermark = {


### PR DESCRIPTION
- Update API.md

I'm not yet sure this approach of having a "User parser" separate from parsing other Social metadata makes sense.   

The only reason I've taken the approach of separating user versus social content is because Twitter marks _content_ with Open Graph tags, as does Facebook.  So there seems to be a common format for marking metadata on content.  However there isn't such a standard apparent for users.
