### PR TITLE
Fix a few ESLint errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,5 +10,9 @@
   "env": {
     "node": true,
     "es6": true
+  },
+
+  "rules": {
+    "no-unused-vars": [2, {"vars": "all", "args": "none"}]
   }
 }

--- a/bin/magnet.js
+++ b/bin/magnet.js
@@ -10,11 +10,11 @@ var urls = process.argv.slice(2);
 
 Promise.all(urls.map(url => exec(url)))
   .then(result => {
-    console.log(result);
+    console.log(result); // eslint-disable-line no-console
     process.exit(0);
   })
 
   .catch(err => {
-    console.error('Error: ' + err.stack);
+    console.error(`Error: ${err.stack}`); // eslint-disable-line no-console
     process.exit(0);
   });

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ var app = require('./app');
 // start listening
 const port = process.env.PORT || config.port;
 const address = process.env.ADDRESS || config.address || '';
-var server = app.listen(port, address, function () {
+var server = app.listen(port, address, () => {
   var host = server.address().address;
   var port = server.address().port;
-  console.log(`magnet service listening at http://${host}:${port}`);
+  console.log(`magnet service listening at http://${host}:${port}`); // eslint-disable-line no-console
 });

--- a/lib/processors/obsolete/twitter-profile.js
+++ b/lib/processors/obsolete/twitter-profile.js
@@ -89,7 +89,9 @@ function parse(doc, res) {
         query: { 'screen_name': result.user_id }
       });
     }
-  } catch(e) {}
+  } catch(e) {
+    // eslint-disable-line no-empty
+  }
 
   return result;
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Physical Web (Alternative) web service implementation",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint .",
     "start": "node index.js",
+    "pretest": "npm run lint",
     "test": "mocha --timeout 20000 --recursive",
     "coverage": "istanbul cover --report html ./node_modules/.bin/_mocha -- --timeout 20000 --recursive"
   },
@@ -41,5 +43,13 @@
   },
   "bin": {
     "magnet": "./bin/magnet.js"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mozilla-magnet/magnet-metadata-service.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mozilla-magnet/magnet-metadata-service/issues"
+  },
+  "homepage": "https://github.com/mozilla-magnet/magnet-metadata-service"
 }


### PR DESCRIPTION
Travis-CI should now also run `eslint .` before executing tests.
