### PR TITLE
Bump to latest Node 4 LTS on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "v4.2.0"
+  - 4


### PR DESCRIPTION
Latest is bestest! https://nodejs.org/en/blog/vulnerability/openssl-may-2016/

Or, if you're feeling dangerous, we can just bump it to latest stable v6, for extra ES6 awesome.
