### PR TITLE
Add temporary hack to hide the default axaet.com URL

### DIFF
--- a/lib/routes/api/metadata/processor.js
+++ b/lib/routes/api/metadata/processor.js
@@ -28,6 +28,10 @@ const types = {
  */
 module.exports = function(url, options) {
   debug('process', url, options);
+  if (url.includes('axaet.com')) {
+    url = 'https://github.com/mozilla-magnet';
+  }
+
   return request(url, options)
     .then(result => {
       debug('got response', result);


### PR DESCRIPTION
 (it ruins scroll performance because of typography - https://github.com/mozilla-magnet/magnet-client/issues/231
