### PR TITLE
Add a call to action metadata field

### DIFF
--- a/lib/routes/api/metadata/processor.js
+++ b/lib/routes/api/metadata/processor.js
@@ -62,7 +62,14 @@ module.exports = function(url, options) {
         debug('parsed', metadata);
 
         return contentServiceRequest.then((res) => {
-          return Object.assign(metadata, res.extra_metadata || {});
+          const addedData = res.extra_metadata || {};
+
+          // Add call to action to every response,
+          // and merge any from the already parsed metadata.
+          addedData.call_to_action = Object.assign({},
+            metadata.call_to_action || {}, res.call_to_action || {});
+
+          return Object.assign({}, metadata, addedData);
         })
         .catch((err) => {
           // Ignore, if the fetch to the content service fails for any reason,

--- a/test/routes/metadata/basic.js
+++ b/test/routes/metadata/basic.js
@@ -419,6 +419,55 @@ describe('basic parsing', () => {
     });
   });
 
+  describe('content service additional data', function() {
+    beforeEach(function(done) {
+      const sites = {
+        objects: [{ url: 'https://example.com' }]
+      };
+      nock('https://example.com')
+        .get('/')
+        .reply(200, '<title>Example</title>', {
+          'Content-Type': 'text/html; charset=utf-8'
+        });
+
+      nock('http://localhost:3000')
+        .post('/v1/search/url', ['https://example.com'])
+        .reply(200, [
+          {
+            id: '4d',
+            short_url: 'https://pm0.io/4d',
+            channel: 'TestChannel',
+            url: 'http://example.com',
+            call_to_action: { call: 'action' },
+            extra_metadata: { image: 'test.jpg' },
+            location: { latitude: 51.5245625, longitude: -0.1362341 },
+            is_virtual: true
+          }
+        ]);
+      supertest(app)
+        .post('/metadata')
+        .send(sites)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+            return;
+          }
+
+          this.result = res.body;
+          done();
+        });
+    });
+
+    it('should include call_to_action data', function() {
+      assert.deepEqual(this.result[0].call_to_action, { call: 'action' });
+    });
+
+    it('should include extra metadata merged into response', function() {
+      assert.equal(this.result[0].image, 'test.jpg');
+    });
+  });
+
   // Not sure if this is a requirement.
   // Supporting this breaks lots of other things.
   describe.skip('unencoded urls', function() {

--- a/test/routes/metadata/basic.js
+++ b/test/routes/metadata/basic.js
@@ -424,6 +424,7 @@ describe('basic parsing', () => {
       const sites = {
         objects: [{ url: 'https://example.com' }]
       };
+
       nock('https://example.com')
         .get('/')
         .reply(200, '<title>Example</title>', {
@@ -444,6 +445,7 @@ describe('basic parsing', () => {
             is_virtual: true
           }
         ]);
+
       supertest(app)
         .post('/metadata')
         .send(sites)


### PR DESCRIPTION
Close #59 

@wilsonpage r?  

Seems like we _could_ just add this to the extra metadata.   I've done it such that it will add a `call_to_action` field on every response in case we end up implementing the call to action 'finder' in the parser.